### PR TITLE
Add cross-platform support to upd8 command

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -4,15 +4,30 @@
 # @author Ricky Rininger
 #============================================================================#
 
+#==============================================================================
+#  OS DETECTION
+#==============================================================================
+
+platform='unknown'
+unamestr="$(uname)"
+
+if [[ "$unamestr" == 'Linux' ]]; then
+    platform='linux'
+elif [[ "$unamestr" == 'Darwin' ]]; then
+    platform='darwin'
+else
+    echo "Unable to identify OS!"
+    exit 1
+fi
+
+#============================================================================#
+#  ENVIRONMENT SETUP
+#============================================================================#
 # Check for .bash_prompt
 if [ -f ~/.bash_prompt ]; then
   source ~/.bash_prompt
 fi
 
-
-#============================================================================#
-#  ENVIRONMENT SETUP
-#============================================================================#
 export VISUAL=nvim
 
 #============================================================================#
@@ -23,8 +38,12 @@ export VISUAL=nvim
 # System Aliases
 #-------------------------------------------------------------
 
-alias upd8='sudo apt update && sudo apt upgrade && \
-            sudo apt autoremove --purge && sudo apt autoclean'
+if [[ $platform == 'darwin' ]]; then
+  alias upd8='brew update && brew upgrade && brew cleanup'
+else
+  alias upd8='sudo apt update && sudo apt upgrade && \
+              sudo apt autoremove --purge && sudo apt autoclean'
+fi
 
 alias vim='nvim'
 


### PR DESCRIPTION
## Cross-platform upd8 command
Previously the upd8 command was only set up for apt-based linux systems (idea/command borrowed from Sean T).

Now it is compatible with homebrew-based macOS systems based on a platform check in the bashrc