### PR TITLE
Add WSL-specific debug alias

### DIFF
--- a/profile
+++ b/profile
@@ -8,12 +8,16 @@
 #  OS DETECTION
 #==============================================================================
 
+unamestr="$(uname -a)"
 platform='unknown'
-unamestr="$(uname)"
+is_wsl='false'
 
-if [[ "$unamestr" == 'Linux' ]]; then
+if [[ "$unamestr" == *'Linux'* ]]; then
     platform='linux'
-elif [[ "$unamestr" == 'Darwin' ]]; then
+    if [[ "$unamestr" == *'microsoft'* ]]; then
+        is_wsl='true'
+    fi
+elif [[ "$unamestr" == *'Darwin'* ]]; then
     platform='darwin'
 else
     echo "Unable to identify OS!"
@@ -26,10 +30,31 @@ fi
 
 if [[ $platform == 'linux' ]]; then
 
-    # Do Linux stuff
+    echo "OS: Linux"
+
+    # Add arm-none-eabi-gcc embedded tools to path
+    ARM_GCC_PATH="$HOME/tools/gcc-arm-none-eabi/bin"
+    PATH="$PATH:$ARM_GCC_PATH"
+
+    # WSL-specific
+    if [[ "$is_wsl" == 'true' ]]; then
+        echo "Loading Microsoft WSL Configuration"
+
+        # CMake bin dir for downloaded binary
+        PATH="$PATH:$HOME/tools/cmake-3.24.0-linux-x86_64/bin"
+        # bin dir for local pip installations
+        PATH="$PATH:$HOME/.local/bin"
+
+        # Alias for gdb debugging
+        alias debug='cmd.exe /c start wsl.exe ~/tools/openocd/bin/openocd -f interface/stlink.cfg -f target/stm32f4x.cfg -c "init" -c "halt" -c "reset halt" & arm-none-eabi-gdb-py --eval-command="target remote localhost:3333"'
+    fi
+
     echo ""
 
 elif [[ $platform == 'darwin' ]]; then
+
+    echo "OS: Darwin"
+    echo ""
 
     # Add homebrew sbin to path
     BREW_SBIN="/usr/local/sbin"
@@ -51,6 +76,7 @@ elif [[ $platform == 'darwin' ]]; then
     QT_PATH="/usr/local/opt/qt/bin"
     PATH="$QT_PATH:$PATH"
 fi
+
 
 # Add ~/bin directory to path
 HOME_BIN="$HOME/bin"


### PR DESCRIPTION
## WSL-specific debug alias
This adds a `debug` alias for WSL setups using OpenOCD and arm-none-eabi-gdb-py.

See notes from October for setup details of using WSL to debug with openOCD, arm-none-eabi toolchain (non-windows), gdb-dashboard, and USB passthrough.
